### PR TITLE
support spaces inside `{}` in `query!` macro format

### DIFF
--- a/concatsql_macro/src/lib.rs
+++ b/concatsql_macro/src/lib.rs
@@ -66,7 +66,8 @@ impl FormatParser {
         let (input, _) = char('{')(input)?;
         let (input, param) = many1(none_of("}"))(input)?;
         let (input, _) = char('}')(input)?;
-        Ok((input, Query::Param(param.into_iter().collect())))
+        let param = param.into_iter().collect::<String>();
+        Ok((input, Query::Param(param.trim().to_string())))
     }
 
     fn brace_open(input: &str) -> IResult<&str, Query> {

--- a/concatsql_macro/tests/macro.rs
+++ b/concatsql_macro/tests/macro.rs
@@ -10,11 +10,12 @@ mod macros {
         let age = "42 OR 1=1; --";
         let sql = query!(r#"SELECT name FROM users WHERE age = {age}"#);
         assert_eq!(sql.simulate(), "SELECT name FROM users WHERE age = '42 OR 1=1; --'");
-        let name = "foo";
         let sql = query!(r#"{name}{name};"#);
         assert_eq!(sql.simulate(), "'foo''foo';");
         let sql = query!(r#"{{name}}"#);
         assert_eq!(sql.simulate(), "{name}");
+        let sql = query!("{ name }");
+        assert_eq!(sql.simulate(), "'foo'");
     }
 
     #[test]


### PR DESCRIPTION
```rust
let name = "foo";
let sql = query!("{ name }");
assert_eq!(sql.simulate(), "'foo'");
```